### PR TITLE
Fix API 403 responses by enabling HTTP/2 and updating request headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest AS builder
 
 LABEL maintainer="chantrail@chantrail.com" \
-      version="0.3.2" \
+      version="0.3.3" \
       description="Stripchat Recorder Docker builder"
 
 RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources
@@ -25,6 +25,18 @@ ENV RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://mirrors.ustc.edu.cn/misc/rustup-install.sh | sh -s -- -y && \
     . /root/.cargo/env && \
     rustup target add x86_64-unknown-linux-gnu
+
+RUN mkdir -vp ${CARGO_HOME:-$HOME/.cargo} && \
+    printf '%s\n' \
+    '[source.crates-io]' \
+    "replace-with = 'ustc'" \
+    '' \
+    '[source.ustc]' \
+    'registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"' \
+    '' \
+    '[registries.ustc]' \
+    'index = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"' \
+    | tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
 
 WORKDIR /app
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,18 +26,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://mirrors.ustc.edu.cn/misc/rustup
     . /root/.cargo/env && \
     rustup target add x86_64-unknown-linux-gnu
 
-RUN mkdir -vp ${CARGO_HOME:-$HOME/.cargo} && \
-    printf '%s\n' \
-    '[source.crates-io]' \
-    "replace-with = 'ustc'" \
-    '' \
-    '[source.ustc]' \
-    'registry = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"' \
-    '' \
-    '[registries.ustc]' \
-    'index = "sparse+https://mirrors.ustc.edu.cn/crates.io-index/"' \
-    | tee -a ${CARGO_HOME:-$HOME/.cargo}/config.toml
-
 WORKDIR /app
 COPY . /app
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -419,6 +419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +545,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +678,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1388,6 +1414,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1817,7 +1817,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stripchat-recorder"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-stream",
  "axum",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["rlib"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.13", features = ["json", "socks", "rustls"], default-features = false }
+reqwest = { version = "0.13", features = ["json", "socks", "rustls", "http2"], default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 sha2 = "0.11"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stripchat-recorder"
-version = "0.3.2"
+version = "0.3.3"
 description = "Stripchat Stream Recorder"
 authors = ["ChanTrail"]
 edition = "2024"

--- a/backend/src/streaming/stripchat.rs
+++ b/backend/src/streaming/stripchat.rs
@@ -52,8 +52,28 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client> {
 /// 构建用于 API 请求的 HTTP 客户端（支持代理，不启用 keepalive）。
 /// Build an HTTP client for API requests (supports proxy, no keepalive).
 fn build_api_client(proxy_url: Option<&str>) -> Result<Client> {
+    // Match the browser headers verified to work without session cookies.
+    let mut headers = reqwest::header::HeaderMap::new();
+    for (name, value) in [
+        ("accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"),
+        ("accept-language", "en-US,en;q=0.6"),
+        ("cache-control", "max-age=0"),
+        ("priority", "u=0, i"),
+        ("sec-ch-ua", "\"Not=A?Brand\";v=\"99\", \"Brave\";v=\"151\", \"Chromium\";v=\"151\""),
+        ("sec-ch-ua-mobile", "?0"),
+        ("sec-ch-ua-platform", "\"Linux\""),
+        ("sec-fetch-dest", "document"),
+        ("sec-fetch-mode", "navigate"),
+        ("sec-fetch-site", "none"),
+        ("sec-fetch-user", "?1"),
+        ("sec-gpc", "1"),
+        ("upgrade-insecure-requests", "1"),
+    ] {
+        headers.insert(name, reqwest::header::HeaderValue::from_static(value));
+    }
     let mut builder = Client::builder()
-        .user_agent(USER_AGENT)
+        .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36")
+        .default_headers(headers)
         .timeout(std::time::Duration::from_secs(30));
 
     if let Some(proxy) = proxy_url

--- a/backend/src/streaming/stripchat.rs
+++ b/backend/src/streaming/stripchat.rs
@@ -55,11 +55,17 @@ fn build_api_client(proxy_url: Option<&str>) -> Result<Client> {
     // Match the browser headers verified to work without session cookies.
     let mut headers = reqwest::header::HeaderMap::new();
     for (name, value) in [
-        ("accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"),
+        (
+            "accept",
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        ),
         ("accept-language", "en-US,en;q=0.6"),
         ("cache-control", "max-age=0"),
         ("priority", "u=0, i"),
-        ("sec-ch-ua", "\"Not=A?Brand\";v=\"99\", \"Brave\";v=\"151\", \"Chromium\";v=\"151\""),
+        (
+            "sec-ch-ua",
+            "\"Not=A?Brand\";v=\"99\", \"Brave\";v=\"151\", \"Chromium\";v=\"151\"",
+        ),
         ("sec-ch-ua-mobile", "?0"),
         ("sec-ch-ua-platform", "\"Linux\""),
         ("sec-fetch-dest", "document"),

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "stripchat-recorder-desktop",
 	"private": true,
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stripchat-recorder-desktop"
-version = "0.3.2"
+version = "0.3.3"
 description = "Stripchat Stream Recorder (Desktop)"
 authors = ["ChanTrail"]
 edition = "2024"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "stripchat-recorder",
-	"version": "0.3.1",
+	"version": "0.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "stripchat-recorder",
-			"version": "0.3.1",
+			"version": "0.3.3",
 			"dependencies": {
 				"@lucide/vue": "^1.20.0",
 				"@tailwindcss/vite": "^4.3.1",
@@ -138,27 +138,6 @@
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmmirror.com/@emnapi/core/-/core-1.11.3.tgz",
-			"integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.3",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.11.3",
-			"resolved": "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.11.3.tgz",
-			"integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -986,6 +965,7 @@
 			"integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": ">=7.24.0 <7.24.7"
 			}
@@ -1929,6 +1909,7 @@
 			"resolved": "https://registry.npmmirror.com/pinia/-/pinia-3.0.4.tgz",
 			"integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vue/devtools-api": "^7.7.7"
 			},
@@ -2180,6 +2161,7 @@
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2236,6 +2218,7 @@
 			"resolved": "https://registry.npmmirror.com/vite/-/vite-8.0.16.tgz",
 			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -2320,6 +2303,7 @@
 			"resolved": "https://registry.npmmirror.com/vue/-/vue-3.5.38.tgz",
 			"integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.5.38",
 				"@vue/compiler-sfc": "3.5.38",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "stripchat-recorder",
 	"private": true,
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "stripchat-recorder-workspace",
 	"private": true,
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"scripts": {
 		"dev": "node scripts/dev.js",
 		"build": "node scripts/release.js",


### PR DESCRIPTION
API polling returned widespread 403 responses while curl could access the same endpoints over HTTP/2.
Reqwest had default features disabled without explicitly enabling HTTP/2.

  - Enable reqwest HTTP/2 support and update API browser headers.
  - Update Cargo.lock with the required dependencies.
  - Remove the USTC Cargo registry override after repeated download timeouts, restoring crates.io.