### PR TITLE
Fix rotated recording filenames and duplicate model groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest AS builder
 
 LABEL maintainer="chantrail@chantrail.com" \
-      version="0.3.4" \
+      version="0.3.5" \
       description="Stripchat Recorder Docker builder"
 
 RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources
@@ -47,7 +47,7 @@ RUN . /root/.cargo/env && npm run build
 FROM debian:latest
 
 LABEL maintainer="chantrail@chantrail.com" \
-      version="0.3.4" \
+      version="0.3.5" \
       description="Stripchat Recorder"
 
 RUN sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list.d/debian.sources

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1722,7 +1722,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stripchat-recorder"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-stream",
  "axum",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stripchat-recorder"
-version = "0.3.4"
+version = "0.3.5"
 description = "Stripchat Stream Recorder"
 authors = ["ChanTrail"]
 edition = "2024"

--- a/backend/src/recording/recorder.rs
+++ b/backend/src/recording/recorder.rs
@@ -418,18 +418,17 @@ impl RecorderManager {
     }
 
     /// Rotate only between complete HLS segments, keeping the download history intact.
-    fn rotate_file(
+    async fn rotate_file(
         self: &Arc<Self>,
         username: &str,
         session_dir: &mut PathBuf,
         emitter: &Arc<dyn Emitter>,
     ) -> Result<()> {
-        let now = chrono::Utc::now();
         let parent = session_dir.parent().unwrap_or(session_dir);
-        let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-        let mut part = 1u64;
-        let next_dir = loop {
-            let candidate = parent.join(format!("{}_part{}_{}", username, part, timestamp));
+        let (now, next_dir) = loop {
+            let now = chrono::Utc::now();
+            let timestamp = now.with_timezone(&Local).format("%Y%m%d_%H%M%S");
+            let candidate = parent.join(format!("{}_{}", username, timestamp));
             let stem = candidate.file_name().unwrap().to_string_lossy();
             if !candidate.exists()
                 && !parent.join(format!("{}.mp4", stem)).exists()
@@ -437,9 +436,10 @@ impl RecorderManager {
                 && !parent.join(format!(".{}.json", stem)).exists()
             {
                 fs::create_dir(&candidate)?;
-                break candidate;
+                break (now, candidate);
             }
-            part += 1;
+            // Wait for a unique timestamp.
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         };
         let format = self.state.get_settings().merge_format;
         let target = parent.join(format!(
@@ -809,7 +809,7 @@ impl RecorderManager {
                     if data.len() > 1000 {
                         let limit = self.state.get_settings().max_recording_duration_secs;
                         if recording_limit_reached(*recorded_secs, limit) {
-                            self.rotate_file(username, session_dir, emitter)?;
+                            self.rotate_file(username, session_dir, emitter).await?;
                             *recorded_secs = 0.0;
                         }
                         let ts_path = session_dir

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "stripchat-recorder-desktop",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "stripchat-recorder-desktop",
-			"version": "0.3.4",
+			"version": "0.3.5",
 			"dependencies": {
 				"@lucide/vue": "^1.20.0",
 				"@tailwindcss/vite": "^4.3.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "stripchat-recorder-desktop",
 	"private": true,
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stripchat-recorder-desktop"
-version = "0.3.4"
+version = "0.3.5"
 description = "Stripchat Stream Recorder (Desktop)"
 authors = ["ChanTrail"]
 edition = "2024"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
 	"productName": "StripchatRecorder",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"identifier": "com.chantrail.stripchat-recorder",
 	"build": {
 		"beforeDevCommand": "npm run dev",

--- a/desktop/src/composables/useRecordings.ts
+++ b/desktop/src/composables/useRecordings.ts
@@ -41,7 +41,17 @@ export interface Group {
 export function usernameFromFile(f: RecordingFile): string {
 	const stem = f.name.replace(/\.[^.]+$/, "");
 	const parts = stem.split("_");
-	return parts.slice(0, -2).join("_");
+	const username = parts.slice(0, -2).join("_");
+	// Group legacy rotations by folder.
+	const pathParts = f.path.split(/[\\/]/);
+	const folder = pathParts[pathParts.length - 2];
+	if (
+		folder && username.startsWith(folder + "_part")
+		&& /^\d+$/.test(username.slice(folder.length + 5))
+	) {
+		return folder;
+	}
+	return username;
 }
 
 /**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "stripchat-recorder",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "stripchat-recorder",
-			"version": "0.3.4",
+			"version": "0.3.5",
 			"dependencies": {
 				"@lucide/vue": "^1.20.0",
 				"@tailwindcss/vite": "^4.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "stripchat-recorder",
 	"private": true,
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/frontend/src/composables/useRecordings.ts
+++ b/frontend/src/composables/useRecordings.ts
@@ -41,7 +41,17 @@ export interface Group {
 export function usernameFromFile(f: RecordingFile): string {
 	const stem = f.name.replace(/\.[^.]+$/, "");
 	const parts = stem.split("_");
-	return parts.slice(0, -2).join("_");
+	const username = parts.slice(0, -2).join("_");
+	// Group legacy rotations by folder.
+	const pathParts = f.path.split(/[\\/]/);
+	const folder = pathParts[pathParts.length - 2];
+	if (
+		folder && username.startsWith(folder + "_part")
+		&& /^\d+$/.test(username.slice(folder.length + 5))
+	) {
+		return folder;
+	}
+	return username;
 }
 
 /**

--- a/modules/contact_sheet/Cargo.toml
+++ b/modules/contact_sheet/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.1"
 edition = "2024"
 
 [[bin]]
-name = "contact_sheet_v030"
+name = "contact_sheet_v031"
 path = "src/main.rs"
 
 [dependencies]

--- a/modules/notify_discord/Cargo.toml
+++ b/modules/notify_discord/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.1"
 edition = "2024"
 
 [[bin]]
-name = "notify_discord_v030"
+name = "notify_discord_v031"
 path = "src/main.rs"
 
 [dependencies]

--- a/modules/notify_telegram/Cargo.lock
+++ b/modules/notify_telegram/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -178,17 +178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.1",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,16 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
-dependencies = [
- "bytes",
- "memchr",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,15 +231,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -755,30 +725,11 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.4",
+ "rand",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-proto"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
-dependencies = [
- "data-encoding",
- "idna",
- "ipnet",
- "jni",
- "once_cell",
- "rand 0.10.2",
- "ring",
- "thiserror 2.0.18",
- "tinyvec",
  "tracing",
  "url",
 ]
@@ -791,12 +742,12 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.2",
+ "hickory-proto",
  "ipconfig",
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -1006,55 +957,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "js-sys"
@@ -1289,7 +1191,6 @@ dependencies = [
  "grammers-client",
  "grammers-mtsender",
  "grammers-session",
- "hickory-proto 0.26.2",
  "md5",
  "pp_utils",
  "tokio",
@@ -1643,17 +1544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.2",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1754,15 +1644,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,15 +1661,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1851,7 +1723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1862,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -1877,22 +1749,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "simd_cesu8"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2156,16 +2012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2301,15 +2147,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/modules/notify_telegram/Cargo.toml
+++ b/modules/notify_telegram/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.1"
 edition = "2024"
 
 [[bin]]
-name = "notify_telegram_v030"
+name = "notify_telegram_v031"
 path = "src/main.rs"
 
 [dependencies]
@@ -16,4 +16,3 @@ futures  = "0.3"
 tokio    = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 dirs = "6"
 md5 = "0.8"
-hickory-proto = "0.26"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "stripchat-recorder-workspace",
 	"private": true,
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"scripts": {
 		"dev": "node scripts/dev.js",
 		"build": "node scripts/release.js",


### PR DESCRIPTION
Removes `_part1` from new rotated filenames. Each file uses the username and timestamp at the file switch, while recording continues in the same session.

Existing `_partN` recordings now appear under the correct model in both web and desktop interfaces, without renaming files.

<img width="361" height="90" alt="image" src="https://github.com/user-attachments/assets/e5165392-beb2-4d46-ac5b-0059616e54cc" />

Fixing issue from #36.